### PR TITLE
use fully qualified domain names with trailing dot to improve dns requests speed

### DIFF
--- a/.config.sample.env
+++ b/.config.sample.env
@@ -111,7 +111,7 @@ export BOOTSTRAP_LONGHORN_BACKUP_TARGET=""
 export BOOTSTRAP_SECRET_S3_ACCESS_KEY=${BOOTSTRAP_MINIO_ROOT_USERNAME}
 # If target is S3, S3 secret key (ex:"secret-key")
 export BOOTSTRAP_SECRET_S3_SECRET_KEY=${BOOTSTRAP_MINIO_ROOT_PASSWORD}
-# If target is S3 and not aws or google, endpoint url (ex:"http://minio.storage:9000")
+# If target is S3 and not aws or google, endpoint url (ex:"http://minio.storage.svc.cluster.local.:9000")
 export BOOTSTRAP_SECRET_S3_ENDPOINT=""
 
 #

--- a/cluster/apps/databases/postgres/pg-cluster.yaml
+++ b/cluster/apps/databases/postgres/pg-cluster.yaml
@@ -21,7 +21,7 @@ spec:
         compression: bzip2
         maxParallel: 8
       destinationPath: s3://postgres-backup-v1/
-      endpointURL: http://minio.storage:80
+      endpointURL: http://minio.storage.svc.cluster.local.:80
       serverName: postgres-v1
       s3Credentials:
         accessKeyId:

--- a/cluster/apps/home/home-assistant/helm-release.yaml
+++ b/cluster/apps/home/home-assistant/helm-release.yaml
@@ -30,7 +30,7 @@ spec:
       tag: 2022.11.2@sha256:4e5088a1c49c1f7fa2f9a51536156c6c009466bb17b4ebb436d0bf4123823dbd
     env:
       TZ: "${TIMEZONE}"
-      POSTGRES_HOST: postgres-rw.default.svc.cluster.local
+      POSTGRES_HOST: postgres-rw.default.svc.cluster.local.
       POSTGRES_DB: "${SECRET_HOME_ASSISTANT_DBNAME}"
     service:
       main:

--- a/cluster/apps/home/home-assistant/patches/postgres.yaml
+++ b/cluster/apps/home/home-assistant/patches/postgres.yaml
@@ -11,7 +11,7 @@ spec:
         image: ghcr.io/onedr0p/postgres-initdb:14.5
         env:
           - name: POSTGRES_HOST
-            value: "postgres-rw.databases.svc.cluster.local"
+            value: "postgres-rw.databases.svc.cluster.local."
           - name: POSTGRES_DB
             value: "${SECRET_HOME_ASSISTANT_DBNAME}"
           - name: POSTGRES_USER

--- a/cluster/apps/home/teslamate/grafana-datasource.yaml
+++ b/cluster/apps/home/teslamate/grafana-datasource.yaml
@@ -13,7 +13,7 @@ data:
     - name: TeslaMate
       type: postgres
       access: proxy
-      url: postgres-r.databases.svc.cluster.local:5432
+      url: postgres-r.databases.svc.cluster.local.:5432
       database: "${SECRET_TESLAMATE_DBNAME}"
       user: "${SECRET_TESLAMATE_DB_USERNAME}"
       secureJsonData:

--- a/cluster/apps/home/teslamate/helm-release.yaml
+++ b/cluster/apps/home/teslamate/helm-release.yaml
@@ -33,7 +33,7 @@ spec:
       # Encrypts Tesla Token
       ENCRYPTION_KEY: "${SECRET_TESLAMATE_ENCRYPTION_KEY}"
       # -- Postgres database hostname
-      DATABASE_HOST: 'postgres-rw.databases.svc.cluster.local'
+      DATABASE_HOST: 'postgres-rw.databases.svc.cluster.local.'
       # -- Postgres database user name
       DATABASE_USER: "${SECRET_TESLAMATE_DB_USERNAME}"
       # -- Postgres database password

--- a/cluster/apps/home/teslamate/patches/postgres.yaml
+++ b/cluster/apps/home/teslamate/patches/postgres.yaml
@@ -11,7 +11,7 @@ spec:
         image: ghcr.io/onedr0p/postgres-initdb:14.5
         env:
           - name: POSTGRES_HOST
-            value: "postgres-rw.databases.svc.cluster.local"
+            value: "postgres-rw.databases.svc.cluster.local."
           - name: POSTGRES_DB
             value: "${SECRET_TESLAMATE_DBNAME}"
           - name: POSTGRES_USER

--- a/cluster/apps/monitoring/grafana/helm-release.yaml
+++ b/cluster/apps/monitoring/grafana/helm-release.yaml
@@ -126,7 +126,7 @@ spec:
         datasources:
           - name: Prometheus
             type: prometheus
-            #url: "http://kube-prometheus-stack-prometheus.monitoring:9090"
+            #url: "http://kube-prometheus-stack-prometheus:9090"
             url: http://thanos-query:9090/
             access: proxy
             isDefault: true

--- a/cluster/apps/monitoring/kube-prometheus-stack/helm-release.yaml
+++ b/cluster/apps/monitoring/kube-prometheus-stack/helm-release.yaml
@@ -224,7 +224,7 @@ spec:
             metrics_path: /minio/v2/metrics/cluster
             scheme: http
             static_configs:
-              - targets: ["minio.storage.svc.cluster.local:80"]
+              - targets: ["minio.storage.svc.cluster.local.:80"]
         #   - job_name: "coredns"
         #     scrape_interval: 1m
         #     scrape_timeout: 10s

--- a/cluster/apps/monitoring/loki/helm-release.yaml
+++ b/cluster/apps/monitoring/loki/helm-release.yaml
@@ -57,7 +57,7 @@ spec:
               s3: s3://loki-chunks-v1@us-east-1/
               bucketnames: loki-chunks-v1
               access_key_id: ${SECRET_MINIO_ROOT_USERNAME}
-              endpoint: http://minio.storage
+              endpoint: http://minio.storage.svc.cluster.local.
               secret_access_key: ${SECRET_MINIO_ROOT_PASSWORD}
               insecure: true
               s3forcepathstyle: true

--- a/cluster/apps/monitoring/thanos/helm-release.yaml
+++ b/cluster/apps/monitoring/thanos/helm-release.yaml
@@ -119,7 +119,7 @@ spec:
       # dnsDiscovery:
       #   enabled: true
       # alertmanagers:
-      #   - http://kube-prometheus-stack-alertmanager.monitoring:9093
+      #   - http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local.:9093
       # clusterName: "${CLUSTER_NAME}"
       # extraFlags:
       #   - "--web.prefix-header=X-Forwarded-Prefix"

--- a/cluster/apps/storage/minio/operator/helm-release.yaml
+++ b/cluster/apps/storage/minio/operator/helm-release.yaml
@@ -37,7 +37,7 @@ spec:
         - name: MINIO_UPDATE
           value: "off"
         - name: MINIO_PROMETHEUS_URL
-          value: http://kube-prometheus-stack-prometheus.monitoring:9090
+          value: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local.:9090
         - name: MINIO_PROMETHEUS_JOB_ID
           value: minio-job
         - name: MINIO_BROWSER_REDIRECT_URL

--- a/cluster/apps/storage/minio/tenant/helm-release.yaml
+++ b/cluster/apps/storage/minio/tenant/helm-release.yaml
@@ -50,7 +50,7 @@ spec:
       #   - name: PROMETHEUS_NAMESPACE
       #     value: "monitoring"
       #   - name: MINIO_PROMETHEUS_URL
-      #     value: http://kube-prometheus-stack-prometheus.monitoring:9090
+      #     value: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local.:9090
       #   - name: MINIO_PROMETHEUS_JOB_ID
       #     value: minio-job
       #   - name: MINIO_BROWSER_REDIRECT_URL

--- a/cluster/core/flux-system/notifications/alert-manager/notification.yaml
+++ b/cluster/core/flux-system/notifications/alert-manager/notification.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   type: alertmanager
-  address: http://kube-prometheus-stack-alertmanager.monitoring:9093/api/v2/alerts/
+  address: http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local.:9093/api/v2/alerts/
 ---
 apiVersion: notification.toolkit.fluxcd.io/v1beta1
 kind: Alert

--- a/tmpl/cluster/thanos-objstore-secret.sops.yaml
+++ b/tmpl/cluster/thanos-objstore-secret.sops.yaml
@@ -9,7 +9,7 @@ stringData:
     type: s3
     config:
       bucket: thanos-v1
-      endpoint: minio.storage:9000
+      endpoint: minio.storage.svc.cluster.local.:9000
       access_key: "${BOOTSTRAP_MINIO_ROOT_USERNAME}"
       secret_key: "${BOOTSTRAP_MINIO_ROOT_PASSWORD}"
       insecure: true


### PR DESCRIPTION
**Description of the change**

with default kubernetes config of ndots:5 in search domain, the best compromise to query domains is :

- in the same namespace, call ${service-name} or ${service-name}.${namespace}.svc.cluster.local. (with trailing dot)

in another namespace, call : 
${service-name}.${namespace}.svc.cluster.local. (with trailing dot)

**Benefits**

less dns queries, more speed

**Possible drawbacks**

check if dns resolution still works

**Additional information**

https://github.com/kubernetes/kubernetes/issues/93824
