### PR TITLE
Revert "fix(helm): update chart gpu-operator to v22.9.1"

### DIFF
--- a/cluster/core/gpu-operator-system/helm-release.yaml
+++ b/cluster/core/gpu-operator-system/helm-release.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       # renovate: registryUrl=https://nvidia.github.io/gpu-operator
       chart: gpu-operator
-      version: v22.9.1
+      version: v22.9.0
       sourceRef:
         kind: HelmRepository
         name: gpu-operator-charts


### PR DESCRIPTION
Reverts nea0d/k8s-homelab-flux#399

Issue when deploying: unknow field ollingUpdate in deamonsets. unknow field updateStrategy in deamonsets